### PR TITLE
API 함수 사용시 response 타입 'body type'으로 추론되도록 수정

### DIFF
--- a/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/src/app/(auth)/login/_components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AxiosError } from 'axios';
+import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import type { ChangeEventHandler, FormEventHandler } from 'react';
 import React, { useRef, useState } from 'react';
@@ -82,9 +82,10 @@ const LoginForm = () => {
         email: emailInputRef.current.value,
         password: passwordInputRef.current.value,
       });
+      // 로그인 성공 후 처리 필요..
       router.replace(dangolPathname.home);
     } catch (e) {
-      if (e instanceof AxiosError) {
+      if (axios.isAxiosError(e)) {
         switch (e.status) {
           case errorCode.Login.UserNotFound:
             setError({

--- a/src/lib/axios/DangolAPIClient.ts
+++ b/src/lib/axios/DangolAPIClient.ts
@@ -1,0 +1,31 @@
+import type { AxiosRequestConfig } from 'axios';
+
+import axiosInstance from './instance';
+
+class DangolAPIClient {
+  async get<T, D = unknown>(url: string, config?: AxiosRequestConfig<D>) {
+    const response = await axiosInstance.get<T>(url, config);
+
+    return response.data;
+  }
+
+  async post<T, D = unknown>(url: string, data?: D, config?: AxiosRequestConfig<D>) {
+    const response = await axiosInstance.post<T>(url, data, config);
+
+    return response.data;
+  }
+
+  async put<T, D = unknown>(url: string, data?: D, config?: AxiosRequestConfig) {
+    const response = await axiosInstance.put<T>(url, data, config);
+
+    return response.data;
+  }
+
+  async delete<T>(url: string, config?: AxiosRequestConfig) {
+    const response = await axiosInstance.delete<T>(url, config);
+
+    return response.data;
+  }
+}
+
+export default new DangolAPIClient();

--- a/src/lib/axios/instance.ts
+++ b/src/lib/axios/instance.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-const dangolAPI = axios.create({
+const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   withCredentials: true,
 });
 
-export default dangolAPI;
+export default axiosInstance;

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -1,15 +1,12 @@
 import { APIPathname } from '@/constants/pathname';
-import { dangolAPI } from '@/lib/axios';
+import DangolAPIClient from '@/lib/axios/DangolAPIClient';
 
-type LoginRequestBody = {
-  email: string;
-  password: string;
-};
+import type { LoginRequestBody, LoginResponseBody } from './types';
 
 export async function login(body: LoginRequestBody) {
-  return await dangolAPI.post(APIPathname.login, body);
+  return await DangolAPIClient.post<LoginResponseBody>(APIPathname.login, body);
 }
 
 export async function logout() {
-  return await dangolAPI.post(APIPathname.logout);
+  return await DangolAPIClient.post<true>(APIPathname.logout);
 }

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -1,0 +1,11 @@
+export type LoginRequestBody = {
+  email: string;
+  password: string;
+};
+
+export type LoginResponseBody = {
+  accessToken: string;
+  refreshToken: string;
+  adminToken: string;
+  user: string;
+};

--- a/src/services/user/types.ts
+++ b/src/services/user/types.ts
@@ -1,0 +1,43 @@
+export type SignUpRequestBody = {
+  email: string;
+  password: string;
+  name: string;
+  phoneNumber: string;
+  isPersonalInfoCollectionAgree: boolean;
+  isPersonalInfoUseAgree: boolean;
+};
+
+export type SignUpResponseBody = {
+  email: string;
+  name: string;
+  phoneNumber: string;
+  isPersonalInfoCollectionAgree: boolean;
+  isPersonalInfoUseAgree: boolean;
+};
+
+export type CheckEmailDuplicateRequestBody = {
+  email: string;
+};
+
+export type FindEmailRequestBody = {
+  name: string;
+  phoneNumber: string;
+};
+
+export type FindEmailResponseBody = {
+  email: string;
+};
+
+export type VerifyEmailForPasswordResetRequestBody = {
+  type: 'signup';
+  email: string;
+  name: string;
+};
+
+export type ResetPasswordRequestBody = {
+  code: string;
+  password: string;
+  type: 'signup';
+  email: string;
+  name: string;
+};

--- a/src/services/user/userService.ts
+++ b/src/services/user/userService.ts
@@ -1,44 +1,32 @@
 import { APIPathname } from '@/constants/pathname';
-import { dangolAPI } from '@/lib/axios';
+import DangolAPIClient from '@/lib/axios/DangolAPIClient';
 
-type SignUpRequestBody = {
-  email: string;
-  password: string;
-  name: string;
-  phoneNumber: string;
-  isPersonalInfoCollectionAgree: boolean;
-  isPersonalInfoUseAgree: boolean;
-};
-
-type CheckEmailDuplicateRequestBody = {
-  email: string;
-};
-
-type FindEmailRequestBody = {
-  name: string;
-  phoneNumber: string;
-};
-
-type VerifyEmailForPasswordResetRequestBody = {};
-
-type ResetPasswordRequestBody = {};
+import type {
+  CheckEmailDuplicateRequestBody,
+  FindEmailRequestBody,
+  FindEmailResponseBody,
+  ResetPasswordRequestBody,
+  SignUpRequestBody,
+  SignUpResponseBody,
+  VerifyEmailForPasswordResetRequestBody,
+} from './types';
 
 export async function signUp(body: SignUpRequestBody) {
-  return await dangolAPI.post(APIPathname.signUp, body);
+  return await DangolAPIClient.post<SignUpResponseBody>(APIPathname.signUp, body);
 }
 
 export async function checkEmailDuplicate(body: CheckEmailDuplicateRequestBody) {
-  return await dangolAPI.post(APIPathname.checkEmailDuplicate, body);
+  return await DangolAPIClient.post<true>(APIPathname.checkEmailDuplicate, body);
 }
 
 export async function findEmail(body: FindEmailRequestBody) {
-  return await dangolAPI.post(APIPathname.findEmail, body);
+  return await DangolAPIClient.post<FindEmailResponseBody>(APIPathname.findEmail, body);
 }
 
 export async function verifyEmailForPasswordReset(body: VerifyEmailForPasswordResetRequestBody) {
-  return await dangolAPI.post(APIPathname.verifyEmailForPasswordReset, body);
+  return await DangolAPIClient.post(APIPathname.verifyEmailForPasswordReset, body);
 }
 
 export async function resetPassword(body: ResetPasswordRequestBody) {
-  return await dangolAPI.post(APIPathname.resetPassword, body);
+  return await DangolAPIClient.post(APIPathname.resetPassword, body);
 }


### PR DESCRIPTION
## 🔥 PR 제목

API 함수 사용시 response 타입 `body type`으로 추론되도록 수정

---

## 📌 변경 사항

- 어떤 기능이 추가되었나요?
1. 기존 axios는 response 타입이 `AxiosResponse` 타입으로 추론하고 있는데 저희가 interceptor에서 response.data로 받도록 적용하고 있기 때문에 그에 맞게 body type으로 추론되도록 수정했습니다. 
